### PR TITLE
Skip syncing Gerrit link comments

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const LINEAR = {
         "public-file-urls-expire-in": "86400"
     },
     ALLOWED_LABELS: (process.env.ALLOWED_LABELS??"").toLowerCase().split(","),
+    GERRIT_COMMENT_PREFIX: "+++ Associated Gerrit changes",
 };
 
 export const SHARED = {

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -441,6 +441,12 @@ export async function linearWebhookHandler(
                 if (!linearComment) continue;
 
                 const { comment, user } = linearComment;
+                
+                // Skip comments that contain Gerrit changes information
+                if (comment.body && comment.body.trim().startsWith(LINEAR.GERRIT_COMMENT_PREFIX)) {
+                    console.log(`Skipping syncing internal Gerrit comment for issue ${ticketName}`);
+                    continue;
+                }
 
                 const modifiedComment = await replaceMentions(
                     comment.body,
@@ -935,6 +941,12 @@ export async function linearWebhookHandler(
                 return skipReason("comment", data.issue!.id, true);
             }
 
+            // Skip comments that contain Gerrit changes information
+            if (data.body && data.body.trim().startsWith(LINEAR.GERRIT_COMMENT_PREFIX)) {
+                console.log(`Skipping syncing internal Gerrit comment for issue #${data.issue?.id}`);
+                return `Skipping syncing internal Gerrit comment for issue #${data.issue?.id}`;
+            }
+        
             // Overrides the outer-scope syncedIssue because comments do not come with teamId
             const syncedIssue = await prisma.syncedIssue.findFirst({
                 where: {


### PR DESCRIPTION
In our case, these comments are quasi-internal: the commits with Gerrit links will get published eventually, but it's just noise to include these comments in public issues.